### PR TITLE
update netty multi thread and change synchronized instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,9 @@ Scripting
 
 ```
 
+## redis-benchmark
+`redis-benchmark -t get,set -n 100000 -q`
+
 
 ## Related Links
 [redis commands](https://redis.io/commands/)

--- a/server/src/main/java/org/github/jrbase/backend/JraftKVDecorator.java
+++ b/server/src/main/java/org/github/jrbase/backend/JraftKVDecorator.java
@@ -5,8 +5,6 @@ import com.alipay.sofa.jraft.rhea.util.ByteArray;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 public class JraftKVDecorator implements BackendProxy {
 
@@ -33,12 +31,7 @@ public class JraftKVDecorator implements BackendProxy {
 
     @Override
     public byte[] bGetAndPut(String key, byte[] value) {
-        final CompletableFuture<byte[]> andPut = delegate.getAndPut(key, value);
-        try {
-            return andPut.get();
-        } catch (InterruptedException | ExecutionException e) {
-            e.printStackTrace();
-        }
-        return new byte[0];
+        // TODO: add async method
+        return delegate.bGetAndPut(key, value);
     }
 }

--- a/server/src/main/java/org/github/jrbase/backend/JraftKVDecorator.java
+++ b/server/src/main/java/org/github/jrbase/backend/JraftKVDecorator.java
@@ -5,6 +5,8 @@ import com.alipay.sofa.jraft.rhea.util.ByteArray;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 public class JraftKVDecorator implements BackendProxy {
 
@@ -31,6 +33,12 @@ public class JraftKVDecorator implements BackendProxy {
 
     @Override
     public byte[] bGetAndPut(String key, byte[] value) {
-        return delegate.bGetAndPut(key, value);
+        final CompletableFuture<byte[]> andPut = delegate.getAndPut(key, value);
+        try {
+            return andPut.get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+        return new byte[0];
     }
 }

--- a/server/src/main/java/org/github/jrbase/handler/CmdHandler.java
+++ b/server/src/main/java/org/github/jrbase/handler/CmdHandler.java
@@ -19,6 +19,8 @@ public class CmdHandler {
 
     private static final String REPLY_OK = "OK";
 
+    private static ScanServerAnnotationConfigure scanServerAnnotationConfigure = new ScanServerAnnotationConfigure();
+
     /**
      * save session login status to HashMap<ChannelHandlerContext, RedisClientContext>
      */
@@ -49,7 +51,7 @@ public class CmdHandler {
         if (clientCmd.getCmd().isEmpty()) {
             replyErrorToClient(ctx, "empty command");
         } else {
-            final ServerCmdHandler serverCmdHandler = ScanServerAnnotationConfigure.instance().get(clientCmd.getCmd());
+            final ServerCmdHandler serverCmdHandler = scanServerAnnotationConfigure.get(clientCmd.getCmd());
             if (serverCmdHandler != null) {
                 //handle server command
                 final String cmdHandlerResult = serverCmdHandler.handle(clientCmd);
@@ -58,6 +60,7 @@ public class CmdHandler {
                 //handle data command
                 clientCmd.setChannel(ctx.channel());
                 clientCmd.setBackendProxy(new JraftKVDecorator(CmdManager.getRheaKVStore()));
+                System.out.println("currentThread: " + Thread.currentThread().getName());
                 CmdManager.process(clientCmd);
             }
         }

--- a/server/src/main/java/org/github/jrbase/handler/CmdHandler.java
+++ b/server/src/main/java/org/github/jrbase/handler/CmdHandler.java
@@ -17,6 +17,8 @@ import static org.github.jrbase.handler.CommandParse.parseMessageToClientCmd;
 
 public class CmdHandler {
 
+    private CmdManager cmdManager;
+
     private static final String REPLY_OK = "OK";
 
     private static ScanServerAnnotationConfigure scanServerAnnotationConfigure = new ScanServerAnnotationConfigure();
@@ -31,6 +33,7 @@ public class CmdHandler {
 
     public CmdHandler(RedisConfigurationOption redisConfigurationOption) {
         this.redisConfigurationOption = redisConfigurationOption;
+        this.cmdManager = new CmdManager();
 //        initHandlerMap();
     }
 
@@ -59,9 +62,8 @@ public class CmdHandler {
             } else {
                 //handle data command
                 clientCmd.setChannel(ctx.channel());
-                clientCmd.setBackendProxy(new JraftKVDecorator(CmdManager.getRheaKVStore()));
-                System.out.println("currentThread: " + Thread.currentThread().getName());
-                CmdManager.process(clientCmd);
+                clientCmd.setBackendProxy(new JraftKVDecorator(cmdManager.getRheaKVStore()));
+                cmdManager.process(clientCmd);
             }
         }
 

--- a/server/src/main/java/org/github/jrbase/handler/CommandParse.java
+++ b/server/src/main/java/org/github/jrbase/handler/CommandParse.java
@@ -11,6 +11,7 @@ public class CommandParse {
      * array:       ['*3', '$3', 'set', '$3', 'key', '$5', 'value']
      */
     public static ClientCmd parseMessageToClientCmd(final String[] redisClientCmdArr) {
+        //TODO: ClientCmd Memory Pool Manage
         ClientCmd clientCmd = new ClientCmd();
         clientCmd.setCmd("");
         clientCmd.setKey("");

--- a/server/src/main/java/org/github/jrbase/handler/annotation/ScanServerAnnotationConfigure.java
+++ b/server/src/main/java/org/github/jrbase/handler/annotation/ScanServerAnnotationConfigure.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Set;
 
 public class ScanServerAnnotationConfigure {
-    private static ScanServerAnnotationConfigure scanServerAnnotationConfigure;
 
     private final static Map<String, ServerCmdHandler> serverCmdHandlerHashMap = new HashMap<>();
 
@@ -20,20 +19,11 @@ public class ScanServerAnnotationConfigure {
         return serverCmdHandlerHashMap.size();
     }
 
-    public static ScanServerAnnotationConfigure instance() {
-        if (scanServerAnnotationConfigure == null) {
-            synchronized (ScanServerAnnotationConfigure.class) {
-                if (scanServerAnnotationConfigure == null) {
-                    scanServerAnnotationConfigure = new ScanServerAnnotationConfigure();
-                    scanServerAnnotationConfigure.doScan();
-                }
-            }
-        }
-        return scanServerAnnotationConfigure;
+    public ScanServerAnnotationConfigure() {
+        this.doScan();
     }
 
     private void doScan() {
-
         String packageName = "org.github.jrbase.handler";
         Reflections reflections = new Reflections(packageName);
 

--- a/server/src/main/java/org/github/jrbase/manager/CmdManager.java
+++ b/server/src/main/java/org/github/jrbase/manager/CmdManager.java
@@ -13,33 +13,20 @@ import static org.github.jrbase.utils.Tools.isCorrectKey;
 
 public class CmdManager {
 
-    private final Object lock = new Object();
+    private static Client client = new Client();
 
-    private CmdManager() {
-        throw new UnsupportedOperationException();
+
+    public CmdManager() {
+        client.init();
+    }
+
+    public RheaKVStore getRheaKVStore() {
+        return client.getRheaKVStore();
     }
 
     private static ScanAnnotationConfigure scanAnnotationConfigure = new ScanAnnotationConfigure();
 
-    private static Client client = null;
-
-    public static Client getClient() {
-        if (client == null) {
-            synchronized (CmdManager.class) {
-                if (client == null) {
-                    client = new Client();
-                    client.init();
-                }
-            }
-        }
-        return client;
-    }
-
-    public static RheaKVStore getRheaKVStore() {
-        return getClient().getRheaKVStore();
-    }
-
-    public static void process(ClientCmd clientCmd) {
+    public void process(ClientCmd clientCmd) {
         CmdProcess cmdProcess;
         cmdProcess = clientCmdToCmdProcess(clientCmd);
         if (cmdProcess == null) {
@@ -64,11 +51,11 @@ public class CmdManager {
         channel.writeAndFlush("-ERR wrong number of arguments for '" + clientCmd.getCmd() + "' command\r\n");
     }
 
-    public static CmdProcess clientCmdToCmdProcess(ClientCmd clientCmd) {
+    public CmdProcess clientCmdToCmdProcess(ClientCmd clientCmd) {
         return scanAnnotationConfigure.get(clientCmd.getCmd());
     }
 
-    public static void shutdown() {
+    public void shutdown() {
         if (client != null) {
             client.shutdown();
         }

--- a/server/src/main/java/org/github/jrbase/manager/CmdManager.java
+++ b/server/src/main/java/org/github/jrbase/manager/CmdManager.java
@@ -13,9 +13,13 @@ import static org.github.jrbase.utils.Tools.isCorrectKey;
 
 public class CmdManager {
 
+    private final Object lock = new Object();
+
     private CmdManager() {
         throw new UnsupportedOperationException();
     }
+
+    private static ScanAnnotationConfigure scanAnnotationConfigure = new ScanAnnotationConfigure();
 
     private static Client client = null;
 
@@ -36,9 +40,10 @@ public class CmdManager {
     }
 
     public static void process(ClientCmd clientCmd) {
-        CmdProcess cmdProcess = clientCmdToCmdProcess(clientCmd);
+        CmdProcess cmdProcess;
+        cmdProcess = clientCmdToCmdProcess(clientCmd);
         if (cmdProcess == null) {
-            cmdProcess = ScanAnnotationConfigure.instance().get(Cmd.OTHER.getCmdName());
+            cmdProcess = scanAnnotationConfigure.get(Cmd.OTHER.getCmdName());
         }
         // check key
         if (!isCorrectKey(clientCmd.getKey())) {
@@ -50,7 +55,6 @@ public class CmdManager {
             sendWrongArgumentMessage(clientCmd);
             return;
         }
-
         final String message = cmdProcess.process(clientCmd);
         clientCmd.getChannel().writeAndFlush(message);
     }
@@ -61,7 +65,7 @@ public class CmdManager {
     }
 
     public static CmdProcess clientCmdToCmdProcess(ClientCmd clientCmd) {
-        return ScanAnnotationConfigure.instance().get(clientCmd.getCmd());
+        return scanAnnotationConfigure.get(clientCmd.getCmd());
     }
 
     public static void shutdown() {

--- a/server/src/main/java/org/github/jrbase/manager/CmdManager.java
+++ b/server/src/main/java/org/github/jrbase/manager/CmdManager.java
@@ -15,7 +15,6 @@ public class CmdManager {
 
     private static Client client = new Client();
 
-
     public CmdManager() {
         client.init();
     }

--- a/server/src/main/java/org/github/jrbase/process/annotation/ScanAnnotationConfigure.java
+++ b/server/src/main/java/org/github/jrbase/process/annotation/ScanAnnotationConfigure.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class ScanAnnotationConfigure {
-    private static ScanAnnotationConfigure scanAnnotationConfigure;
+
 
     private final static Map<String, CmdProcess> cmdProcessManager = new HashMap<>();
 
@@ -20,20 +20,11 @@ public class ScanAnnotationConfigure {
         return cmdProcessManager.size();
     }
 
-    public static ScanAnnotationConfigure instance() {
-        if (scanAnnotationConfigure == null) {
-            synchronized (ScanAnnotationConfigure.class) {
-                if (scanAnnotationConfigure == null) {
-                    scanAnnotationConfigure = new ScanAnnotationConfigure();
-                    scanAnnotationConfigure.doScan();
-                }
-            }
-        }
-        return scanAnnotationConfigure;
+    public ScanAnnotationConfigure() {
+        this.doScan();
     }
 
     private void doScan() {
-
         String packageName = "org.github.jrbase.process";
         Reflections reflections = new Reflections(packageName);
 

--- a/server/src/main/java/org/github/jrbase/server/JRBaseServer.java
+++ b/server/src/main/java/org/github/jrbase/server/JRBaseServer.java
@@ -45,7 +45,7 @@ public class JRBaseServer {
         }
 
         EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup(1);
+        EventLoopGroup workerGroup = new NioEventLoopGroup(8);
         try {
             ServerBootstrap b = new ServerBootstrap();
             b.group(bossGroup, workerGroup)

--- a/server/src/main/java/org/github/jrbase/server/ServerHandler.java
+++ b/server/src/main/java/org/github/jrbase/server/ServerHandler.java
@@ -5,7 +5,6 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import org.github.jrbase.config.RedisConfigurationOption;
 import org.github.jrbase.handler.CmdHandler;
 
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.logging.Logger;
 
 
@@ -15,12 +14,10 @@ import java.util.logging.Logger;
 public class ServerHandler extends SimpleChannelInboundHandler<String> {
 
     private CmdHandler cmdHandler;
-    private ThreadPoolExecutor threadPoolExecutor;
 
-    public ServerHandler(RedisConfigurationOption redisConfigurationOption, ThreadPoolExecutor threadPoolExecutor) {
+    public ServerHandler(RedisConfigurationOption redisConfigurationOption) {
 
         this.cmdHandler = new CmdHandler(redisConfigurationOption);
-        this.threadPoolExecutor = threadPoolExecutor;
     }
 
     private static final Logger logger = Logger.getLogger(JRBaseServer.class.getName());
@@ -33,7 +30,7 @@ public class ServerHandler extends SimpleChannelInboundHandler<String> {
 
     @Override
     public void channelRead0(ChannelHandlerContext ctx, String msg) {
-        threadPoolExecutor.execute(() -> cmdHandler.handleMsg(ctx, msg));
+        cmdHandler.handleMsg(ctx, msg);
     }
 
     @Override

--- a/server/src/main/java/org/github/jrbase/server/ServerHandler.java
+++ b/server/src/main/java/org/github/jrbase/server/ServerHandler.java
@@ -2,7 +2,6 @@ package org.github.jrbase.server;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import org.github.jrbase.config.RedisConfigurationOption;
 import org.github.jrbase.handler.CmdHandler;
 
 import java.util.logging.Logger;
@@ -15,9 +14,8 @@ public class ServerHandler extends SimpleChannelInboundHandler<String> {
 
     private CmdHandler cmdHandler;
 
-    public ServerHandler(RedisConfigurationOption redisConfigurationOption) {
-
-        this.cmdHandler = new CmdHandler(redisConfigurationOption);
+    public ServerHandler(CmdHandler cmdHandler) {
+        this.cmdHandler = cmdHandler;
     }
 
     private static final Logger logger = Logger.getLogger(JRBaseServer.class.getName());

--- a/server/src/main/java/org/github/jrbase/server/ServerInitializer.java
+++ b/server/src/main/java/org/github/jrbase/server/ServerInitializer.java
@@ -6,15 +6,16 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.codec.string.StringEncoder;
 import org.github.jrbase.config.RedisConfigurationOption;
+import org.github.jrbase.handler.CmdHandler;
 
 /**
  * Creates a newly configured {@link ChannelPipeline} for a new channel.
  */
 public class ServerInitializer extends ChannelInitializer<SocketChannel> {
-    private RedisConfigurationOption redisConfigurationOption;
+    private CmdHandler cmdHandler;
 
     public ServerInitializer(RedisConfigurationOption redisConfigurationOption) {
-        this.redisConfigurationOption = redisConfigurationOption;
+        this.cmdHandler = new CmdHandler(redisConfigurationOption);
     }
 
     @Override
@@ -25,6 +26,6 @@ public class ServerInitializer extends ChannelInitializer<SocketChannel> {
         pipeline.addLast(new StringEncoder());
 
         // and then business logic.
-        pipeline.addLast(new ServerHandler(redisConfigurationOption));
+        pipeline.addLast(new ServerHandler(cmdHandler));
     }
 }

--- a/server/src/main/java/org/github/jrbase/server/ServerInitializer.java
+++ b/server/src/main/java/org/github/jrbase/server/ServerInitializer.java
@@ -6,22 +6,12 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.codec.string.StringEncoder;
 import org.github.jrbase.config.RedisConfigurationOption;
-import org.github.jrbase.thread.MyThreadFactory;
-
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Creates a newly configured {@link ChannelPipeline} for a new channel.
  */
 public class ServerInitializer extends ChannelInitializer<SocketChannel> {
     private RedisConfigurationOption redisConfigurationOption;
-
-    private final ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(1, 1,
-            5L, TimeUnit.MINUTES,
-            new LinkedBlockingQueue<>(), new MyThreadFactory(), new ThreadPoolExecutor.AbortPolicy());
-
 
     public ServerInitializer(RedisConfigurationOption redisConfigurationOption) {
         this.redisConfigurationOption = redisConfigurationOption;
@@ -35,6 +25,6 @@ public class ServerInitializer extends ChannelInitializer<SocketChannel> {
         pipeline.addLast(new StringEncoder());
 
         // and then business logic.
-        pipeline.addLast(new ServerHandler(redisConfigurationOption, threadPoolExecutor));
+        pipeline.addLast(new ServerHandler(redisConfigurationOption));
     }
 }

--- a/server/src/test/groovy/org/github/jrbase/handler/annotation/ScanServerAnnotationConfigureTest.groovy
+++ b/server/src/test/groovy/org/github/jrbase/handler/annotation/ScanServerAnnotationConfigureTest.groovy
@@ -4,18 +4,20 @@ import org.github.jrbase.handler.ServerCmdHandler
 import spock.lang.Specification
 
 class ScanServerAnnotationConfigureTest extends Specification {
+    ScanServerAnnotationConfigure scanServerAnnotationConfigure = new ScanServerAnnotationConfigure()
+
     def "ScanServerAnnotationConfigure"() {
         when:
-        ServerCmdHandler serverCmdHandler = ScanServerAnnotationConfigure.instance().get("ping")
+        ServerCmdHandler serverCmdHandler = scanServerAnnotationConfigure.get("ping")
         then:
         serverCmdHandler.getCmdName() == "ping"
-        ScanServerAnnotationConfigure.instance().getCount() == 3
+        scanServerAnnotationConfigure.getCount() == 3
     }
 
     def "testAnnotationSingleton"() {
         when:
-        ServerCmdHandler serverCmdHandler = ScanServerAnnotationConfigure.instance().get("ping")
-        ServerCmdHandler serverCmdHandler2 = ScanServerAnnotationConfigure.instance().get("ping")
+        ServerCmdHandler serverCmdHandler = scanServerAnnotationConfigure.get("ping")
+        ServerCmdHandler serverCmdHandler2 = scanServerAnnotationConfigure.get("ping")
         then:
         serverCmdHandler == serverCmdHandler2
     }

--- a/server/src/test/groovy/org/github/jrbase/manager/CmdManagerTest.groovy
+++ b/server/src/test/groovy/org/github/jrbase/manager/CmdManagerTest.groovy
@@ -13,6 +13,7 @@ import spock.lang.Specification
 import static org.github.jrbase.dataType.RedisDataType.STRINGS
 
 class CmdManagerTest extends Specification {
+    CmdManager cmdManager = new CmdManager()
 
     def "testCmdProcessManagerForgetRegisterCmdProcess2"() {
         given:
@@ -20,14 +21,14 @@ class CmdManagerTest extends Specification {
         def keys = Cmd.getLookup().values()
         keys.forEach({ cmd ->
             clientCmd.setCmd(cmd.cmdName)
-            def cmdProcess = CmdManager.clientCmdToCmdProcess(clientCmd)
+            def cmdProcess = cmdManager.clientCmdToCmdProcess(clientCmd)
             Assert.assertNotNull("you forget register command: " + clientCmd.getCmd(), cmdProcess)
         })
     }
 
     def "ClientCmdToCmdProcess0"() {
         expect:
-        CmdManager.clientCmdToCmdProcess(new ClientCmd(input)) == output
+        cmdManager.clientCmdToCmdProcess(new ClientCmd(input)) == output
 
         where:
         input     | output
@@ -37,7 +38,7 @@ class CmdManagerTest extends Specification {
 
     def "ClientCmdToCmdProcess"() {
         expect:
-        CmdManager.clientCmdToCmdProcess(new ClientCmd(input)).getClass().getSimpleName() == output
+        cmdManager.clientCmdToCmdProcess(new ClientCmd(input)).getClass().getSimpleName() == output
 
         where:
         input | output
@@ -59,7 +60,7 @@ class CmdManagerTest extends Specification {
         clientCmd.setChannel(channel)
         clientCmd.setArgs([] as String[])
         when:
-        CmdManager.process(clientCmd)
+        cmdManager.process(clientCmd)
         then:
         1 * clientCmd.getChannel().writeAndFlush(_)
     }
@@ -74,7 +75,7 @@ class CmdManagerTest extends Specification {
         clientCmd.setChannel(channel)
 
         when:
-        CmdManager.process(clientCmd)
+        cmdManager.process(clientCmd)
         then:
         1 * channel.writeAndFlush('-ERR wrong number of arguments for \'\' command\r\n')
     }
@@ -89,7 +90,7 @@ class CmdManagerTest extends Specification {
         clientCmd.setChannel(channel)
 
         when:
-        CmdManager.process(clientCmd)
+        cmdManager.process(clientCmd)
         then:
         1 * channel.writeAndFlush('-ERR wrong number of arguments for \'123\' command\r\n')
     }
@@ -104,7 +105,7 @@ class CmdManagerTest extends Specification {
         clientCmd.setChannel(channel)
 
         when:
-        CmdManager.process(clientCmd)
+        cmdManager.process(clientCmd)
         then:
         1 * channel.writeAndFlush('-ERR wrong number of arguments for \'get\' command\r\n')
     }
@@ -119,7 +120,7 @@ class CmdManagerTest extends Specification {
         clientCmd.setChannel(channel)
 
         when:
-        CmdManager.process(clientCmd)
+        cmdManager.process(clientCmd)
         then:
         1 * channel.writeAndFlush('-ERR wrong number of arguments for \'set\' command\r\n')
     }

--- a/server/src/test/groovy/org/github/jrbase/process/annotation/ScanServerAnnotationConfigureTest.groovy
+++ b/server/src/test/groovy/org/github/jrbase/process/annotation/ScanServerAnnotationConfigureTest.groovy
@@ -5,18 +5,19 @@ import spock.lang.Specification
 
 class ScanServerAnnotationConfigureTest extends Specification {
 
+    ScanAnnotationConfigure scanAnnotationConfigure = new ScanAnnotationConfigure()
     def "ScanAnnotationConfigure"() {
         when:
-        CmdProcess cmdProcess = ScanAnnotationConfigure.instance().get("hget")
+        CmdProcess cmdProcess = scanAnnotationConfigure.get("hget")
         then:
         cmdProcess.getCmdName() == "hget"
-        ScanAnnotationConfigure.instance().getCount() == 20
+        scanAnnotationConfigure.getCount() == 20
     }
 
     def "testAnnotationSingleton"() {
         when:
-        CmdProcess cmdProcess = ScanAnnotationConfigure.instance().get("get")
-        CmdProcess cmdProcess2 = ScanAnnotationConfigure.instance().get("get")
+        CmdProcess cmdProcess = scanAnnotationConfigure.get("get")
+        CmdProcess cmdProcess2 = scanAnnotationConfigure.get("get")
         then:
         cmdProcess == cmdProcess2
     }


### PR DESCRIPTION

<!--
Thank you for contributing to JRBase! Please read JRBase's [CONTRIBUTING](https://github.com/jrbase/jrbase/blob/master/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Improve performance
`redis-benchmark -t get -n 10000`
1745.20 requests per second => 16638.94 requests per second
`redis-benchmark -t set -n 10000`
121.87 requests per second => 487.85 requests per second

### What is changed and how it works?
update Netty NioEventLoopGroup 8 threads and change synchronized instance(ScanServerAnnotationConfigure,ScanAnnotationConfigure) to preloading to avoid synchronize cost and first new cost
All data is unchanged and local variable,  remove synchronized

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - [ ] Unit test
 - [ ] Integration test
 - [ ] Manual test (add detailed scripts or steps below)
 - [ ] No code

Code changes

 - [ ] Has exported function/method change
 - [ ] Has exported variable/fields change
 - [ ] Has interface methods change
 - [ ] Has persistent data change

Side effects

 - [x] Possible performance regression
 - [ ] Increased code complexity
 - [ ] Breaking backward compatibility

Related changes

 - [ ] Need to cherry-pick to the release branch
 - [x] Need to update the documentation

Release note

 - [ ] Write release note for bug-fix or new feature.
